### PR TITLE
Improved go to item with procedure support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "STARLIMS VS Code Extension",
   "description": "Unofficial dictionary explorer (and more) for STARLIMS.",
   "license": "SEE LICENSE IN LICENSE.md",
-  "version": "1.2.41",
+  "version": "1.2.42",
   "publisher": "MariusPopovici",
   "author": {
     "name": "Marius Popovici, Christoph Döllinger, Jan Bouecke"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1060,36 +1060,80 @@ export async function activate(context: vscode.ExtensionContext) {
     "STARLIMS.GoToServerScript",
     async () => {
       var editor = vscode.window.activeTextEditor;
-      if (editor) {
-        // get the script name from editor cursor position
-        const position = editor.selection.active;
-        const scriptName = editor.document.getText(editor.document.getWordRangeAtPosition(position, /[\w\.]+/));
+      if (!editor) {
+        return;
+      } 
 
-        // search on server to find the script
-        const itemFound = await enterpriseProvider.search(scriptName, "SS", true);
+      // get the script name from editor cursor position
+      const position = editor.selection.active;
+      const scriptName = editor.document.getText(editor.document.getWordRangeAtPosition(position, /[\w\.]+/));
+      const aScriptNameComponents = scriptName.split(".");
+      let found = false;
 
-        // open the first item found
-        if (itemFound !== undefined) {
-          await vscode.commands.executeCommand("STARLIMS.GetLocal", itemFound);
-
-          // get new editor
-          editor = vscode.window.activeTextEditor;
-
-          if (editor) {
-            // split the script name to get the procedure name
-            const aScriptName = scriptName.split(".");
-            if (aScriptName.length > 2) {
-              const procName = `:PROCEDURE ${aScriptName[2]};`;
-              // search the opened document for the procedure name and set cursor to the line of occurrence
-              const procPosition = editor.document.getText().indexOf(procName);
-              if (procPosition > 0) {
-                const position = editor.document.positionAt(procPosition);
-                editor.selection = new vscode.Selection(position, position);
-                editor.revealRange(new vscode.Range(position, position));
-              }
-            }
+      if (aScriptNameComponents.length === 0) {
+        found = false;
+      } 
+      else if (aScriptNameComponents.length === 1) {
+        // this is probably a procedure in the current script
+        found = findProcedureInEditor(scriptName, editor);
+        if (!found) {
+          // it could be in an :INCLUDEd library
+          const libraryNames = findIncludedScripts(editor);
+          for (const library of libraryNames) {
+            found = await findScriptOnServer(library, scriptName);
+            if (found) { break; }
           }
         }
+      } else {
+        // this is a server script or external script procedure, search on server to find the main script
+        const procedureName = aScriptNameComponents.length > 2 ? aScriptNameComponents[2] : undefined;
+        found = await findScriptOnServer(scriptName, procedureName);  
+      }
+
+      if (!found) {
+        vscode.window.showErrorMessage("Couldn't find selected item.");
+      }
+      
+      async function findScriptOnServer(scriptName: string, procedureName: string | undefined) {
+        let itemFound = await enterpriseProvider.search(scriptName, "SS", true);
+        if (itemFound) {
+          await vscode.commands.executeCommand("STARLIMS.GetLocal", itemFound);
+          // get new editor
+          editor = vscode.window.activeTextEditor;
+          if (editor && procedureName) {
+            // find procedure in the newly opened editor
+            return findProcedureInEditor(procedureName, editor);
+          } 
+          return true;
+        } {
+          return false;
+        }
+      }
+
+      function findProcedureInEditor(procedureName: string, editor: vscode.TextEditor) : boolean {
+        const procName = `:PROCEDURE ${[procedureName]};`;
+        // search the opened document for the procedure name and set cursor to the line of occurrence
+        const procPosition = editor.document.getText().indexOf(procName);
+        if (procPosition > 0) {
+          const position = editor.document.positionAt(procPosition);
+          editor.selection = new vscode.Selection(position, position);
+          editor.revealRange(new vscode.Range(position, position));
+          return true;
+        } else {
+          return false;
+        }
+      }
+
+      function findIncludedScripts(editor: vscode.TextEditor) {
+        // find all included scripts in the current document
+        let regex = /:INCLUDE\s+"([^"]*)";/g;
+        let matches;
+        let libraryNames = [];
+        while ((matches = regex.exec(editor.document.getText())) !== null) {
+          libraryNames.push(matches[1]); // Add the captured group to the array
+        }
+
+        return libraryNames;
       }
     }
   );
@@ -1165,7 +1209,7 @@ export async function activate(context: vscode.ExtensionContext) {
       const autoDetectConfig = [
         {
           command: "STARLIMS.GoToServerScript",
-          keywords: ["lims.CallServer", "ExecFunction", "CreateUDObject", "SubmitToBatch"]
+          keywords: ["lims.CallServer", "ExecFunction", "CreateUDObject", "SubmitToBatch", "DoProc"]
         },
         {
           command: "STARLIMS.GoToDataSource",


### PR DESCRIPTION
- Include DoProc in "go to server script" command keywords 

- Added support for procedures in go to item. Works for the following scenarios:
  - a procedure in an external server script
  - a local procedure in the current script
  - a procedure in an included script 

`:INCLUDE "___Dummy.a_library";

DoProc("Utilities.SQLFunctions.ConvertToInteger", {"123"});

DoProc("Test");

DoProc("Test2");

DoProc("this_doesnt_exist");

:PROCEDURE Test;
  UsrMes("1234");
:ENDPROC;
`