### PR TITLE
Bug fixes, improved package upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,3 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated icons
 - Storing user password is secure storage vs settings.json
 - Show form resources for HTML and XFD forms
+
+## [1.2.67] - 2023-09-13
+
+- Initial support for editing form resources for HTML and XFD forms

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Features:
 To Do:
 
 - Move forms and scripts
-- Edit form resources
 - Create a HTML form designer
 - Implement table support including a schema and ERD generator / viewer
 - Rename items
@@ -117,5 +116,5 @@ New features:
 - Go to script/form under the cursor
 - View checked out items, check in pending, undo check out, view checked out items from all uses, refresh checked out items tree
 - Global search / full text search in code items
-- View form resources
+- View and edit form resources
 - Misc. bug fixes

--- a/package.json
+++ b/package.json
@@ -656,6 +656,7 @@
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "@xmldom/xmldom": "^0.7.13",
     "jsdom": "^22.1.0",
-    "node-fetch": "^2.6.12"
+    "node-fetch": "^2.6.12",
+    "react": "^18.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "STARLIMS VS Code Extension",
   "description": "Unofficial dictionary explorer (and more) for STARLIMS.",
   "license": "SEE LICENSE IN LICENSE.md",
-  "version": "1.2.65",
+  "version": "1.2.66",
   "icon": "resources/extension/starlimsvscode.png",
   "publisher": "MariusPopovici",
   "author": {
@@ -656,7 +656,6 @@
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "@xmldom/xmldom": "^0.7.13",
     "jsdom": "^22.1.0",
-    "node-fetch": "^2.6.12",
-    "react": "^18.2.0"
+    "node-fetch": "^2.6.12"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,8 @@ import { EnterpriseItemType, EnterpriseTreeDataProvider, TreeEnterpriseItem } fr
 import { EnterpriseService } from "./services/enterpriseService";
 import { EnterpriseTextDocumentContentProvider } from "./providers/enterpriseTextContentProvider";
 import path = require("path");
-import { DataViewPanel } from "./panels/DataViewPanel";
+import { ResourcesDataViewPanel } from "./panels/ResourcesDataViewPanel";
+import { GenericDataViewPanel } from "./panels/GenericDataViewPanel";
 import { cleanUrl, executeWithProgress } from "./utilities/miscUtils";
 import { CheckedOutTreeDataProvider } from "./providers/checkedOutTreeDataProvider";
 
@@ -134,6 +135,11 @@ export async function activate(context: vscode.ExtensionContext) {
           const sdpPackage = context.asAbsolutePath("dist/SCM_API.sdp");
           executeWithProgress(async () => {
             await enterpriseService.upgradeBackend(sdpPackage);
+            const selection = await vscode.window.showInformationMessage(`We recommend that you restart Visual Studio Code.`,
+              'Restart', 'Cancel');
+            if (selection === "Restart") {
+              vscode.commands.executeCommand("workbench.action.reloadWindow");
+            }
           }, "Upgrading the extension backend API.");
         }
       }
@@ -319,13 +325,11 @@ export async function activate(context: vscode.ExtensionContext) {
     const result = await enterpriseService.getTableDefinition(item.uri);
     const tableName = item.uri.split('/').pop();
     if (result) {
-      DataViewPanel.render(context.extensionUri, {
+      GenericDataViewPanel.render(context.extensionUri, {
         name: tableName,
         data: result,
         title: `Table Definition: ${tableName}`
-      },
-        enterpriseService,
-        enterpriseTreeProvider);
+      });
     }
   }
 
@@ -341,7 +345,7 @@ export async function activate(context: vscode.ExtensionContext) {
     let oParams = await enterpriseService.getFormResources(remoteUri, item.language);
 
     // render the data view panel
-    DataViewPanel.render(context.extensionUri, oParams, enterpriseService, 
+    ResourcesDataViewPanel.render(context.extensionUri, oParams, enterpriseService, 
                          enterpriseTreeProvider);
   }
 
@@ -1053,13 +1057,11 @@ export async function activate(context: vscode.ExtensionContext) {
         const result = await enterpriseService.runScript(remoteUri);
         if (result?.success) {
           const dataSourceName = remoteUri.split('/').pop();
-          DataViewPanel.render(context.extensionUri, {
+          GenericDataViewPanel.render(context.extensionUri, {
             name: dataSourceName,
             data: result.data,
             title: `Data Source Output: ${dataSourceName}`
-          },
-            enterpriseService,
-            enterpriseTreeProvider);
+          });
         }
         outputChannel.appendLine(result.data);
         outputChannel.show();

--- a/src/panels/GenericDataViewPanel.ts
+++ b/src/panels/GenericDataViewPanel.ts
@@ -3,7 +3,7 @@ import { getNonce } from "../utilities/getNonce";
 import { getUri } from "../utilities/getUri";
 
 export class GenericDataViewPanel {
-  public static currentPanel: DataViewPanel | undefined;
+  public static currentPanel: GenericDataViewPanel | undefined;
   private readonly _panel: vscode.WebviewPanel;
   private _disposables: vscode.Disposable[] = [];
   private _data: string;

--- a/src/panels/GenericDataViewPanel.ts
+++ b/src/panels/GenericDataViewPanel.ts
@@ -1,0 +1,121 @@
+import * as vscode from "vscode";
+import { getNonce } from "../utilities/getNonce";
+import { getUri } from "../utilities/getUri";
+
+export class GenericDataViewPanel {
+  public static currentPanel: DataViewPanel | undefined;
+  private readonly _panel: vscode.WebviewPanel;
+  private _disposables: vscode.Disposable[] = [];
+  private _data: string;
+  private _name: string;
+  private _title: string;
+
+  private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, payload: any) {
+    this._panel = panel;
+    this._data = payload.data;
+    this._name = payload.name;
+    this._title = payload.title;
+
+    // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
+    // the panel or when the panel is closed programmatically)
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+
+    // Set the HTML content for the webview panel
+    this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);
+
+    // Set an event listener to listen for messages passed from the webview context
+    this._setWebviewMessageListener(this._panel.webview);
+  }
+
+  // render the webview panel
+  public static render(extensionUri: vscode.Uri, payload: any) {
+    const panel = vscode.window.createWebviewPanel("data-results", payload.title, vscode.ViewColumn.One, {
+      enableScripts: true,
+      localResourceRoots: [vscode.Uri.joinPath(extensionUri, "dist")]
+    });
+
+    GenericDataViewPanel.currentPanel = new GenericDataViewPanel(panel, extensionUri, payload);
+  }
+
+  public dispose() {
+    GenericDataViewPanel.currentPanel = undefined;
+
+    this._panel.dispose();
+
+    while (this._disposables.length) {
+      const disposable = this._disposables.pop();
+      if (disposable) {
+        disposable.dispose();
+      }
+    }
+  }
+
+  /**
+   * Defines and returns the HTML that should be rendered within the webview panel.
+   *
+   * @remarks This is also the place where *references* to CSS and JavaScript files
+   * are created and inserted into the webview HTML.
+   *
+   * @param webview A reference to the extension webview
+   * @param extensionUri The URI of the directory containing the extension
+   * @returns A template string literal containing the HTML that should be
+   * rendered within the webview panel
+   */
+  private _getWebviewContent(webview: vscode.Webview, extensionUri: vscode.Uri) {
+    const nonce = getNonce();
+    const webviewUri = getUri(webview, extensionUri, ["dist", "webview.js"]);
+    const styleUri = getUri(webview, extensionUri, ["dist", "style.css"]);
+    const codiconUri = getUri(webview, extensionUri, ["dist", "codicon.css"]);
+
+    // TIP: Install the es6-string-html VS Code extension to enable code highlighting below
+    const html = /*html*/ `
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; font-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
+          <link rel="stylesheet" href="${styleUri}">
+          <link rel="stylesheet" href="${codiconUri}">
+          <title>${this._title}</title>
+        </head>
+        <body>
+          <h1 id="title">${this._title}</h1>
+          <section>
+            <vscode-data-grid id="data-grid" generate-header="sticky" aria-label="Data Source Results"></vscode-data-grid>
+          </section>
+          <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
+        </body>
+      </html>
+    `;
+
+    return html;
+  }
+
+  /**
+   * Sets up an event listener to listen for messages passed from the webview context and
+   * executes code based on the message that is received.
+   *
+   * @param webview A reference to the extension webview
+   */
+  private _setWebviewMessageListener(webview: vscode.Webview) {
+    webview.onDidReceiveMessage(
+      (message: any) => {
+        const command = message.command;
+        const data = message.data;
+        switch (command) {
+          case "requestData":
+            // the webview controller (main.ts) sends a requestData message after initializing
+            // we send it the data using a receiveData message
+            webview.postMessage({
+              command: "receiveData",
+              payload: this._data
+            });
+            break;
+        }
+      },
+      undefined,
+      this._disposables
+    );
+  }
+}

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -30,8 +30,14 @@ import {
 //
 // provideVSCodeDesignSystem().register(allComponents);
 
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeDataGrid(), vsCodeDataGridCell(), 
-                                     vsCodeDataGridRow(), vsCodeDropdown(), vsCodeOption());
+provideVSCodeDesignSystem().register(
+  vsCodeButton(),
+  vsCodeDataGrid(),
+  vsCodeDataGridCell(),
+  vsCodeDataGridRow(),
+  vsCodeDropdown(),
+  vsCodeOption()
+);
 
 // Get access to the VS Code API from within the webview context
 const vscode = acquireVsCodeApi();
@@ -53,24 +59,27 @@ function main() {
   const addButton = document.getElementById("add-button") as Button;
   addButton.addEventListener("click", () => {
     const grid = document.getElementById("data-grid") as DataGrid;
-    if(grid.columnDefinitions === null || grid.rowsData === null) {
+    if (grid.columnDefinitions === null || grid.rowsData === null) {
       return;
     }
 
     // add a new row to the grid
-    const newRow : any = {};
+    const newRow: any = {};
 
     // generate new guid
     const guid = () => {
-      const s4 = () => Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+      const s4 = () =>
+        Math.floor((1 + Math.random()) * 0x10000)
+          .toString(16)
+          .substring(1);
       return `${s4() + s4()}-${s4()}-${s4()}-${s4()}-${s4() + s4() + s4()}`;
     };
 
     // add guid to first column
     newRow["column0"] = guid();
-    
+
     // add empty strings to the rest of the columns
-    for(let i = 1; i < grid.columnDefinitions.length; i++) {
+    for (let i = 1; i < grid.columnDefinitions.length; i++) {
       newRow[`column${i}`] = "";
     }
 
@@ -123,12 +132,18 @@ function setVSCodeMessageListener() {
 
           // Set rowsData based on extracted data
           grid.rowsData = data.map((rowData: string[]) => {
-            const row : any = {};
+            const row: any = {};
             rowData.forEach((value, index) => {
-              row[`column${index}`] = value.toString().trim();
+              row[`column${index}`] = value?.toString().trim();
             });
             return row;
           });
+
+          // set grid column widths for large number of columns otherwise the output is unintelligible
+          // TODO: replace 150px below with max-content when this is fixed: https://github.com/microsoft/vscode-webview-ui-toolkit/issues/473
+          if (columns.length > 10) {
+            grid.setAttribute("grid-template-columns", columns.map(() => `150px`).join(` `));
+          }
         }
         break;
     }
@@ -212,8 +227,8 @@ function unsetCellEditable(cell: DataGridCell) {
 // Syncs changes made in an editable cell with the
 // underlying data structure of a vscode-data-grid
 function syncCellChanges(cell: DataGridCell) {
-  const column : any = cell.columnDefinition;
-  const row : any = cell.rowData;
+  const column: any = cell.columnDefinition;
+  const row: any = cell.rowData;
   if (column && row) {
     const originalValue = row[column.columnDataKey];
     const newValue = cell.innerText;
@@ -228,7 +243,7 @@ function syncCellChanges(cell: DataGridCell) {
 function saveData() {
   const grid = document.getElementById("data-grid") as DataGrid;
 
-  if(grid.columnDefinitions === null || grid.rowsData === null) {
+  if (grid.columnDefinitions === null || grid.rowsData === null) {
     return;
   }
 
@@ -236,22 +251,22 @@ function saveData() {
     columns: (string | undefined)[];
     data: any[];
   }
-  let gridData : GridData = {
+  let gridData: GridData = {
     columns: [],
     data: []
   };
-  
+
   // Update the gridData object with the latest data
   gridData.columns = grid.columnDefinitions.map((columnDefinition) => columnDefinition.title);
-  gridData.data = grid.rowsData.map((rowData : any) =>
-  grid.columnDefinitions?.map((columnDefinition : any) => rowData[columnDefinition.columnDataKey])
+  gridData.data = grid.rowsData.map((rowData: any) =>
+    grid.columnDefinitions?.map((columnDefinition: any) => rowData[columnDefinition.columnDataKey])
   );
 
   // Send the gridData object to the extension context
   const title = (document.getElementById("title") as HTMLInputElement).innerText;
-  if(title.includes("Resources")) {
+  if (title.includes("Resources")) {
     vscode.postMessage({ command: "saveResourcesData", payload: JSON.stringify(gridData) });
-  } else if(title.includes("Table")) {
+  } else if (title.includes("Table")) {
     vscode.postMessage({ command: "saveTableData", payload: JSON.stringify(gridData) });
   }
 }


### PR DESCRIPTION
Fixed broken data source results and table schema views.

- Split DataViewPanel into ResourcesDataViewPanel and GenericDataViewPanel 
- GenericDataViewPanel is used to render a generic array to a data grid
- ResourcesDataViewPanel is specialized to render form resources
- Both share the same main.ts file for now
- Configured the grid to display fixed width columns if # of columns is  > than 10. When there are a lot of columns the output is unintelligible  
- Added a prompt to restart VS Code after a backend upgrade. It should be done in case new endpoints or features are being called on during the extension start and the backend is missing that functionality because the upgrade hasn't been done yet. This could leave the extension in a broken state so a reload should be done.