### PR TITLE
fix issue on command "saveResourcesData"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-starlims",
-  "version": "1.2.76",
+  "version": "1.2.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-starlims",
-      "version": "1.2.76",
+      "version": "1.2.83",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@vscode/webview-ui-toolkit": "^1.2.2",

--- a/src/panels/ResourcesDataViewPanel.ts
+++ b/src/panels/ResourcesDataViewPanel.ts
@@ -184,8 +184,8 @@ export class ResourcesDataViewPanel {
               xmlData +=
                 "\t<ResourcesTable>\n" +
                 `\t\t<Guid>${row[0]}</Guid>\n` +
-                `\t\t<ResourceId>${row[1]}</ResourceId>\n` +
-                `\t\t<ResourceValue>${row[2]}</ResourceValue>\n` +
+                `\t\t<ResourceId>${this.escapeXml(row[1])}</ResourceId>\n` +
+                `\t\t<ResourceValue>${this.escapeXml(row[2])}</ResourceValue>\n` +
                 "\t</ResourcesTable>\n";
             }
             xmlData += "</ResourcesDataset>";
@@ -236,5 +236,18 @@ export class ResourcesDataViewPanel {
       undefined,
       this.disposables
     );
+  }
+
+  /*
+   * escape xml tag text special symbol
+   */
+  private escapeXml(unsafe: string) {
+    var result
+    result = unsafe.replace("<", "&lt;")
+    result = unsafe.replace(">", "&gt;")
+    result = unsafe.replace("&", "&amp;")
+    result = unsafe.replace("\'", "&apos;")
+    result = unsafe.replace("\"", "&quot;")
+    return result
   }
 }

--- a/src/panels/ResourcesDataViewPanel.ts
+++ b/src/panels/ResourcesDataViewPanel.ts
@@ -184,8 +184,8 @@ export class ResourcesDataViewPanel {
               xmlData +=
                 "\t<ResourcesTable>\n" +
                 `\t\t<Guid>${row[0]}</Guid>\n` +
-                `\t\t<ResourceId>${this.escapeXml(row[1])}</ResourceId>\n` +
-                `\t\t<ResourceValue>${this.escapeXml(row[2])}</ResourceValue>\n` +
+                `\t\t<ResourceId>${escapeXml(row[1])}</ResourceId>\n` +
+                `\t\t<ResourceValue>${escapeXml(row[2])}</ResourceValue>\n` +
                 "\t</ResourcesTable>\n";
             }
             xmlData += "</ResourcesDataset>";
@@ -237,17 +237,17 @@ export class ResourcesDataViewPanel {
       this.disposables
     );
   }
+}
 
-  /*
-   * escape xml tag text special symbol
-   */
-  private escapeXml(unsafe: string) {
-    var result
-    result = unsafe.replace("<", "&lt;")
-    result = unsafe.replace(">", "&gt;")
-    result = unsafe.replace("&", "&amp;")
-    result = unsafe.replace("\'", "&apos;")
-    result = unsafe.replace("\"", "&quot;")
-    return result
-  }
+/*
+* escape xml tag text special symbol
+*/
+export function escapeXml(unsafe: string) {
+  let result = unsafe;
+  result = result.replace(/&/g, "&amp;"); // first handle symbol '&' because other escape operations generate '&'
+  result = result.replace(/</g, "&lt;");
+  result = result.replace(/>/g, "&gt;");
+  result = result.replace(/'/g, "&apos;");
+  result = result.replace(/"/g, "&quot;");
+  return result;
 }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -3,13 +3,29 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
+import { escapeXml } from '../../panels/ResourcesDataViewPanel';
 // import * as myExtension from '../../extension';
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
+	// unit test for escape xml special symbols in string
+	test('ResourcesDataViewPanel.escapeXml', () => {
+		assert.strictEqual(escapeXml("\""), "&quot;")
+		assert.strictEqual(escapeXml("'"), "&apos;")
+		assert.strictEqual(escapeXml("&"), "&amp;")
+		assert.strictEqual(escapeXml(">"), "&gt;")
+		assert.strictEqual(escapeXml("<"), "&lt;")
+
+		// test multiple occurances
+		assert.strictEqual(escapeXml("&value& & "), "&amp;value&amp; &amp; ")
+		assert.strictEqual(escapeXml("<value>"), "&lt;value&gt;")
+		assert.strictEqual(escapeXml("\"quoted string\""), "&quot;quoted string&quot;")
+
+		const notEscapedString = "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ +=!@#$%^*()?:{}|`\n\t\v"
+		assert.strictEqual(escapeXml(notEscapedString), notEscapedString)
+
+		assert.strictEqual(escapeXml(''), '') // empty string
+	})
+
 });


### PR DESCRIPTION
I found when saving resources with special xml symbol(character like `&`, `\`, etc.) in <ResourceId> and <ResourceValue> tag, the command will not do correct escaping, which will break the saved resources string on STARLIMS server. STARLIM will thrown error when trying the parsing those broken data