### PR TITLE
Fix issue on add server script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/*.sdp
 *.js
 *.js.map
 .env
+CLAUDE.md

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "STARLIMS VS Code Extension",
   "description": "Unofficial dictionary explorer (and more) for STARLIMS.",
   "license": "SEE LICENSE IN LICENSE.md",
-  "version": "1.2.97",
+  "version": "1.2.98",
   "icon": "resources/extension/starlimsvscode.png",
   "publisher": "MariusPopovici",
   "author": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1080,19 +1080,18 @@ export async function activate(context: vscode.ExtensionContext) {
       }
 
       // check out the item unless it's an enterprise item category
-      let sUri = `/${root}/${categoryName}/${appName}/${selectedItemType}/${itemName}`;
+      
+      let sUri = appName !== 'N/A' ? `/${root}/${categoryName}/${appName}/${selectedItemType}/${itemName}` :
+        `/${root}/${categoryName}/${itemName}`;
+
       if (itemType.indexOf("CAT") === -1) {
         let bSuccess = await enterpriseService.checkOutItem(sUri, language);
-        if (bSuccess) {
-          enterpriseTreeProvider.setItemCheckedOutStatus(selectedItem, true, language);
-          vscode.commands.executeCommand("STARLIMS.GetLocal", selectedItem);
-        }
       }
 
-      enterpriseTreeProvider.refresh();
+      await enterpriseTreeProvider.refresh();            
 
       // wait for the tree to refresh
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await new Promise(resolve => setTimeout(resolve, 3000));
 
       // open newly created item (works only if section is expanded)
       let newItem = await enterpriseTreeProvider.getTreeItemByUri(sUri);


### PR DESCRIPTION
- fixed issue with selecting tree item after adding a global server script
- increased the wait on tree refresh; not ideal, but i can't figure out a way to hook into the refresh completed event